### PR TITLE
Finnish translations, minor general translation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Home assistant integration from lawnmower using the robotic-mower connect APP.
 
 ## Tested models
   - Adano RM6
+  - Brücke RM501
 
 ## Install
 #### Manually
@@ -19,7 +20,7 @@ Search for *Sunseeker robotic mower* and add it.
 You must now choose a barnd and a name for the device. Email and password for the robotic-mower connect APP.
 
 ## Translation
-English and danish
+English, Danish and Finnish
 
 # Entities
 ## lawn mower

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Standby, Mowing, Going home, Charging, Border, Error
 **Zone 4** - percentage of the start of zone 4
 
 ## Text
-*Format of the text fields: Start and end time format HH:MM. Add Trim to mowe the border. ex. "06:15 - 17:00 Trim" or "06:15 - 17:00"*
+*Format of the text fields: Start and end time format HH:MM. Add Trim to mowe the border. ex. "06:15 - 17:00 Trim", "06:15 - 17:00", "08:00 - 24:00" or whole day "00:00 - 24:00"*
 
 **Schedule Monday** - Text field to update the moday schedule. 
 

--- a/custom_components/sunseeker/sunseeker.py
+++ b/custom_components/sunseeker/sunseeker.py
@@ -72,6 +72,7 @@ class SunseekerDevice:
         self.rain_en = self.devicedata["data"].get("rainFlag")
         self.rain_delay_set = int(self.devicedata["data"].get("rainDelayDuration"))
         self.rain_delay_left = self.devicedata["data"].get("rainDelayLeft")
+        self.rain_status = int(self.devicedata["data"].get("rainStatusCode"))
         if self.devicedata["data"].get("onlineFlag"):
             self.deviceOnlineFlag = '{"online":"1"}'
         self.zoneOpenFlag = self.settings["data"].get("zoneOpenFlag")
@@ -160,7 +161,10 @@ class SunseekerSchedule:
             if Start is not None:
                 asc.start = time.strftime("%H:%M", time.gmtime(int(Start) * 60))[0:5]
             if End is not None:
-                asc.end = time.strftime("%H:%M", time.gmtime(int(End) * 60))[0:5]
+                if int(End) == 1440:
+                    asc.end = "24:00"
+                else:
+                    asc.end = time.strftime("%H:%M", time.gmtime(int(End) * 60))[0:5]
             if Trimming is not None:
                 asc.trim = Trimming
 

--- a/custom_components/sunseeker/text.py
+++ b/custom_components/sunseeker/text.py
@@ -44,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> N
     async_add_entities(
         [
             SunseekerScheduleText(
-                coordinator, "Schedule Thursday", 4, "unseeker_schedule_text_4"
+                coordinator, "Schedule Thursday", 4, "sunseeker_schedule_text_4"
             )
             for coordinator in robot_coordinators(hass, entry)
         ]
@@ -52,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities) -> N
     async_add_entities(
         [
             SunseekerScheduleText(
-                coordinator, "Schedule Fridays", 5, "sunseeker_schedule_text_5"
+                coordinator, "Schedule Friday", 5, "sunseeker_schedule_text_5"
             )
             for coordinator in robot_coordinators(hass, entry)
         ]

--- a/custom_components/sunseeker/translations/en.json
+++ b/custom_components/sunseeker/translations/en.json
@@ -55,11 +55,11 @@
         "sunseeker_wifi_level": {
           "name": "Wifi strength"
         },
-              "sunseeker_rain_status": {
+        "sunseeker_rain_status": {
           "name": "Rain sensor",
           "state": {
             "Dry": "Dry",
-            "Dry countdown": "Dry countdownr",
+            "Dry countdown": "Dry countdown",
             "Wet": "Wet",
             "Unknown": "Unknown"
           }

--- a/custom_components/sunseeker/translations/fi.json
+++ b/custom_components/sunseeker/translations/fi.json
@@ -1,0 +1,209 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Käyttäjätili on jo määritelty"
+        },
+        "error": {
+            "connection_error": "Yhteys epäonnistui"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "model": "Merkki",
+                    "name": "Nimi",
+                    "email": "Sähköposti",
+                    "password": "Salasana"
+                }
+            }
+        }
+    },
+    "entity": {
+      "sensor": {
+        "sunseeker_state_error": {
+          "name": "Virhetila"
+        },
+        "sunseeker_mower_state": {
+          "name": "Robotin tila",
+          "state": {
+            "Standby": "Valmiustila",
+            "Mowing": "Leikkaa",
+            "On the way home": "Palaa kotiin",
+            "Charging": "Lataa",
+            "Mowing border": "Reunaleikkaus",
+            "Unknown": "Tuntematon",
+            "Unknown4": "Mode 4"
+          }
+        },
+        "sunseeker_battery": {
+          "name": "Akku"
+        },
+        "sunseeker_rain_delay_set": {
+          "name": "Sadeviive"
+        },
+        "sunseeker_sensor_counter": {
+          "name": "Sadetunnistimen laskuri"
+        },
+        "sunseeker_mowing_time": {
+          "name": "Leikkausaika"
+        },
+        "sunseeker_error": {
+          "name": "Virhekoodi"
+        },
+        "sunseeker_error_text": {
+          "name": "Virhe"
+        },
+        "sunseeker_wifi_level": {
+          "name": "Wifi voimakkuus"
+        },
+          "sunseeker_rain_status": {
+            "name": "Sadetunnistin",
+            "state": {
+              "Dry": "Kuivaa",
+              "Dry countdown": "Kuivumiseen aikaa",
+              "Wet": "Märkää",
+              "Unknown": "Tuntematon"
+          }
+        },
+        "sunseekerzone1": {
+          "name": "Alue 1 aloitus"
+        },
+        "sunseekerzone2": {
+          "name": "Alue 2 aloitus"
+        },
+        "sunseekerzone3": {
+          "name": "Alue 3 aloitus"
+        },
+        "sunseekerzone4": {
+          "name": "Alue 4 aloitus"
+        }
+      },
+      "binary_sensor": {
+        "sunseeker_dock": {
+          "name": "Telakka",
+          "state": {
+            "Away": "Poissa",
+            "Home": "Kotona",
+            "Unknown": "Tuntematon"
+          }
+        },
+        "sunseeker_rain_sensor_active": {
+          "name": "Sadetunnistin päällä"
+        },
+        "sunseeker_multizone": {
+          "name": "Monialueleikkaus"
+        },
+        "sunseeker_multizoneauto": {
+          "name": "Monialueleikkaus autom."
+        },
+        "sunseeker_schedule": {
+          "name": "Ajastus"
+        },
+        "sunseeker_online": {
+          "name": "Yhteys",
+          "state": {
+            "Connected": "Yhdistetty",
+            "Disconnected": "Yhteys katkennut",
+            "Unknown": "Tuntematon"
+          }
+        }
+      },
+      "lawn_mower": {
+        "sunseeker_lawnmower": {
+          "state": {
+            "Standby": "Valmiustila",
+            "Mowing": "Leikkaa",
+            "On the way home": "Palaa kotiin",
+            "Charging": "Lataa",
+            "Mowing border": "Reunaleikkaus",
+            "Unknown": "Tuntematon",
+            "Unknown4": "Mode 4"
+          }
+        }
+      },
+      "button": {
+        "sunseeker_start": {
+          "name": "Leikkaa"
+        },
+        "sunseeker_pause": {
+          "name": "Pysäytä"
+        },
+        "sunseeker_border": {
+          "name": "Rajaleikkaus"
+        },
+        "sunseeker_home": {
+          "name": "Palaa kotiin"
+        }
+      },
+      "device_tracker": {
+        "sunseeker_tracker": {
+          "name": "Robotin sijainti"
+        }
+      },
+      "switch": {
+        "sunseeker_rain_sensor": {
+          "name": "Sadetunnistin"
+        },
+        "sunseeker_multi_zone": {
+          "name": "Monialueleikkaus"
+        },
+        "sunseeker_multi_zone_auto": {
+          "name": "Monialueleikkaus autom."
+        },
+        "schedule_active": {
+          "name": "Ajastus"
+        }
+      },
+      "number": {
+        "sunseeker_rain_delay": {
+          "name": "Sadeviive"
+        },
+        "sunseeker_zone1": {
+          "name": "Alue 1 aloitus"
+        },
+        "sunseeker_zone2": {
+          "name": "Alue 2 aloitus"
+        },
+        "sunseeker_zone3": {
+          "name": "Alue 3 aloitus"
+        },
+        "sunseeker_zone4": {
+          "name": "Alue 4 aloitus"
+        },
+        "sunseeker_mulpro1": {
+          "name": "Alue 1 prioriteetti"
+        },
+        "sunseeker_mulpro2": {
+          "name": "Alue 2 prioriteetti"
+        },
+        "sunseeker_mulpro3": {
+          "name": "Alue 3 prioriteetti"
+        },
+        "sunseeker_mulpro4": {
+          "name": "Alue 4 prioriteetti"
+        }
+      },
+      "text": {
+        "sunseeker_schedule_text_1": {
+          "name": "Ajastus maanantaina"
+        },
+        "sunseeker_schedule_text_2": {
+          "name": "Ajastus tiistaina"
+        },
+        "sunseeker_schedule_text_3": {
+          "name": "Ajastus keskiviikkona"
+        },
+        "sunseeker_schedule_text_4": {
+          "name": "Ajastus torstaina"
+        },
+        "sunseeker_schedule_text_5": {
+          "name": "Ajastus perjantaina"
+        },
+        "sunseeker_schedule_text_6": {
+          "name": "Ajastus lauantaina"
+        },
+        "sunseeker_schedule_text_7": {
+          "name": "Ajastus sunnuntaina"
+        }
+      }
+    }
+  }

--- a/custom_components/sunseeker/translations/fi.json
+++ b/custom_components/sunseeker/translations/fi.json
@@ -27,7 +27,7 @@
           "state": {
             "Standby": "Valmiustila",
             "Mowing": "Leikkaa",
-            "On the way home": "Palaa kotiin",
+            "On the way home": "Palaamassa kotiin",
             "Charging": "Lataa",
             "Mowing border": "Reunaleikkaus",
             "Unknown": "Tuntematon",
@@ -128,7 +128,7 @@
           "name": "Pysäytä"
         },
         "sunseeker_border": {
-          "name": "Rajaleikkaus"
+          "name": "Reunaleikkaus"
         },
         "sunseeker_home": {
           "name": "Palaa kotiin"

--- a/custom_components/sunseeker/translations/fi.json
+++ b/custom_components/sunseeker/translations/fi.json
@@ -38,10 +38,10 @@
           "name": "Akku"
         },
         "sunseeker_rain_delay_set": {
-          "name": "Sadeviive"
+          "name": "Sadetunnistin viive"
         },
         "sunseeker_sensor_counter": {
-          "name": "Sadetunnistimen laskuri"
+          "name": "Sadetunnistin jäljellä"
         },
         "sunseeker_mowing_time": {
           "name": "Leikkausaika"
@@ -59,7 +59,7 @@
             "name": "Sadetunnistin",
             "state": {
               "Dry": "Kuivaa",
-              "Dry countdown": "Kuivumiseen aikaa",
+              "Dry countdown": "Odottaa kuivumista",
               "Wet": "Märkää",
               "Unknown": "Tuntematon"
           }
@@ -155,7 +155,7 @@
       },
       "number": {
         "sunseeker_rain_delay": {
-          "name": "Sadeviive"
+          "name": "Sadetunnistin viive"
         },
         "sunseeker_zone1": {
           "name": "Alue 1 aloitus"


### PR DESCRIPTION
- Added: Finnish translations
- Fix: "Schedule Thursday" was newer translated because of typo. Because of this corresponding entity name was misleading.
- Fix: "Schedule Friday" fixed to same form as others
- Fix: typo in english translation "Dry countdown"
