### PR TITLE
Fix AttributeError on MQTT updates: call device.update_devices()

### DIFF
--- a/custom_components/sunseeker/sunseeker_mqtt.py
+++ b/custom_components/sunseeker/sunseeker_mqtt.py
@@ -875,7 +875,7 @@ class SunseekermqttController:
                 if device.update_timer:
                     device.update_timer.cancel()
                 device.update_timer = Timer(
-                    10, self.Sunseeker.update_devices, [device.devicesn]
+                    10, device.update_devices, []
                 )
                 device.update_timer.start()
         if "consumable_items" in datanode:
@@ -1041,7 +1041,7 @@ class SunseekermqttController:
                 if device.update_timer:
                     device.update_timer.cancel()
                 device.update_timer = Timer(
-                    10, self.Sunseeker.update_devices, [device.devicesn]
+                    10, device.update_devices, []
                 )
                 device.update_timer.start()
         # msg/event code V1


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'SunseekerRoboticmower' object has no attribute 'update_devices'` thrown on every MQTT status update whose handler hits the `forceupdate` branch.

Likely root cause of the symptom reported in #58 ("Sensors update only infrequently"): because the `Timer` callback errors out immediately, the scheduled per-device refresh never runs, so devices only update from whatever data arrives in the next MQTT push.

## Reproduction

Any HA install on `1.2.11` (or any version since the refactor below) logs the following whenever an MQTT message causes an `errortype` transition:

```
ERROR (Thread-XX (handle_mqtt_message)) [custom_components.sunseeker.sunseeker_mqtt]
  MQTT message error: 'SunseekerRoboticmower' object has no attribute 'update_devices'
ERROR (Thread-XX (handle_mqtt_message)) [custom_components.sunseeker.sunseeker_mqtt]
  MQTT message: {"wifi_rssi":-53,"ip":"…","total_min":75071,"ssid":"…",
                 "deviceSn":"…","mode":4,"errortype":2,…}
```

## Root cause

Commit [`448aa1e`](https://github.com/Sdahl1234/Sunseeker-lawn-mower/commit/448aa1e) ("Move device related from Sunseeker to sunseeker device") moved `update_devices` from `SunseekerRoboticmower` onto `SunseekerDevice` and dropped the `device_sn` parameter (each device now knows its own serial). The two MQTT handlers that scheduled a refresh via that method were not updated:

```python
device.update_timer = Timer(
    10, self.Sunseeker.update_devices, [device.devicesn]
)
```

`self.Sunseeker` is the parent `SunseekerRoboticmower` controller — which no longer has `update_devices`. The `Timer` raises on fire, the refresh never happens.

## Fix

Call the method on the device directly. `device` is already in scope, bound to the correct `SunseekerDevice`, and `SunseekerDevice.update_devices(self)` takes no arguments:

```python
device.update_timer = Timer(
    10, device.update_devices, []
)
```

This restores the pre-refactor semantics: a 10-second-delayed per-device refresh of the device that just signalled `forceupdate`.

The same change is applied in both call sites — the X-gen2/V status handler (line 878) and the V1 event-code handler (line 1044).

## Verification

Applied the patch on a `1.2.11` deployment (HA 2026.5.1, one Sunseeker X3 mower) and restarted Home Assistant. Before: `AttributeError` on every MQTT status push. After: integration sets up cleanly, all 40 entities populate with live state, no `update_devices`-related entries in the log.

## Risk

Two-line change, narrow scope, restores the original semantic intent of the refactor. No public API affected. Should resolve #58 (or at least the part of it caused by the never-running scheduled refresh).
